### PR TITLE
Export the AgoraRTCErrorCode enum instead of just the declaration

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -27,7 +27,7 @@ export interface AgoraRTCError {
   name: string;
 }
 
-export declare enum AgoraRTCErrorCode {
+export enum AgoraRTCErrorCode {
   UNEXPECTED_ERROR = "UNEXPECTED_ERROR",
   UNEXPECTED_RESPONSE = "UNEXPECTED_RESPONSE",
   TIMEOUT = "TIMEOUT",


### PR DESCRIPTION
Previously when using this library from typescript, importing `AgoraRTCErrorCode` would pass type checks even though nothing was actually exported, causing an undefined exception at run time.

For example:

```ts
import { AgoraRTCErrorCode, createMicrophoneAndCameraTracks } from 'agora-rtc-react';

try {
  createMicrophoneAndCameraTracks()
} catch (e) {
  if (e.code === AgoraRTCErrorCode.PERMISSION_DENIED) {
                                     // ^--- throws exception because AgoraRTCErrorCode is undefined
    console.log("User did not give camera/mic permissions");
  } else {
    throw e;
  }
}
```

After this PR, the code example will work without an exception being thrown.