### PR TITLE
fix: add type of createScreenVideoTrack enable and disable

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -169,6 +169,30 @@ export declare function createMicrophoneAudioTrack(config?: MicrophoneAudioTrack
  * @returns React hook that can be used to access the screenshare tracks
  * @category Wrapper
  */
+ export declare function createScreenVideoTrack(config: ScreenVideoTrackInitConfig, withAudio: 'enable'): () => {
+    ready: boolean;
+    tracks: [ILocalVideoTrack, ILocalAudioTrack];
+    error: AgoraRTCError | null;
+};
+/**
+ * Creates and stores the screenshare tracks
+ * @param config Config for the screenshare tracks
+ * @param withAudio Try and create audio track as well (needs browser support)
+ * @returns React hook that can be used to access the screenshare tracks
+ * @category Wrapper
+ */
+ export declare function createScreenVideoTrack(config: ScreenVideoTrackInitConfig, withAudio: 'disable'): () => {
+    ready: boolean;
+    track: ILocalVideoTrack;
+    error: AgoraRTCError | null;
+};
+/**
+ * Creates and stores the screenshare tracks
+ * @param config Config for the screenshare tracks
+ * @param withAudio Try and create audio track as well (needs browser support)
+ * @returns React hook that can be used to access the screenshare tracks
+ * @category Wrapper
+ */
 export declare function createScreenVideoTrack(config: ScreenVideoTrackInitConfig, withAudio?: 'enable' | 'disable' | 'auto'): () => {
     ready: boolean;
     tracks: ILocalVideoTrack | [ILocalVideoTrack, ILocalAudioTrack];


### PR DESCRIPTION
Return wrong type when I execute the following code.
`createScreenVideoTrack({ encoderConfig: '480p_1' }, 'disable')()`

I just want to return only `ILocalVideoTrack` but this code of type tracks is `ILocalVideoTrack | [ILocalVideoTrack, ILocalAudioTrack]`
I think that's wrong because I seted withAudio: disable so never return `ILocalAudioTrack` so I added two type of type for enable and disable.

This is my first pull request to oss so might be something mistake or exist any other solution then please let me know.
